### PR TITLE
add option to index multiple themes/stories at once

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-    types: [ opened, synchronized ]
+    types: [ opened, synchronized, closed ]
 
 jobs:
   build-test:

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+*.lcov
 *.cover
 *.py,cover
 .hypothesis/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -45,6 +45,7 @@
                 "-c",
                 "pytest.ini"
             ],
+            "internalConsoleOptions": "openOnSessionStart",
         }
     ]
 }

--- a/examples/basics.py
+++ b/examples/basics.py
@@ -1,16 +1,21 @@
 import totolo
+import os.path
 
 
 def example():
     #: get the latest main branch version of the ontology
     ontology = totolo.remote()
     print(ontology)
+
     # <2945 themes, 4475 stories>
-    # ontology.print_warnings()
+    #: use ontology.print_warnings() to check if there are any formatting issues
     print("---")
-    ontology.write("/home/mo/themes")
-    ontology = totolo.files("/home/mo/themes")
-    print(ontology)
+
+    home = os.path.expanduser('~')
+    ontology.write(f"{home}/themes")
+    ontology_local = totolo.files(f"{home}/themes")
+    print(ontology_local)
+
     # <2945 themes, 4475 stories>
     print("---")
 
@@ -18,6 +23,7 @@ def example():
     for theme in ontology.themes():
         if "romantic love" in theme.name:
             print(theme)
+
     # b'personal freedom vs. romantic love'[3]
     # b'romantic love'[3]
     print("---")
@@ -25,6 +31,7 @@ def example():
     #: check the definition of a theme
     love = ontology.theme["love"]
     love.print()
+
     # (...)
     print("---")
 
@@ -32,6 +39,8 @@ def example():
     story = ontology.story["play: Macbeth (1606)"]
     for weight, theme in story.iter_themes():
         print(f"{weight:<10} {theme.name}")
+
+    # (...)
     print("---")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,4 +33,5 @@ disable = [
     "unsubscriptable-object",           # pylint gets it wrong
     "unsupported-assignment-operation", # pylint gets it wrong
     "unsupported-delete-operation",     # pylint gets it wrong
+    "super-with-arguments",             # pylint gets it wrong
 ]

--- a/tests/test_entries.py
+++ b/tests/test_entries.py
@@ -66,8 +66,8 @@ bar
         warnings = list(entry.validate())
         assert len(warnings) == 1
         assert "junk in entry" in warnings[0]
-        assert list(entry.ancestors()) == ["foo"]
-        assert list(entry.descendants()) == ["foo"]
+        assert list(entry.iter_ancestor_names()) == ["foo"]
+        assert list(entry.iter_descendant_names()) == ["foo"]
         with pytest.raises(KeyError):
             del entry["foo"]
 

--- a/tests/test_toset.py
+++ b/tests/test_toset.py
@@ -1,0 +1,51 @@
+import totolo
+from totolo.collection import TOSet
+
+
+class TestTOSet:
+    def test_toset_strings(self):
+        ts = TOSet(['foo', 'bar'])
+        assert sorted(ts.names()) == ['bar', 'foo']
+        assert ts.ontology() is None
+
+    def test_toset_ontology(self):
+        prefix = "tests/data/sample-2023.07.23"
+        ontology = totolo.files(prefix)
+        toset = ontology.theme[["romantic love"]]
+        assert toset.ontology() is ontology
+
+    def test_toset_dataframe(self):
+        ontology = totolo.files("tests/data/sample-2023.07.23")
+        df = ontology.theme[["electricity"]].dataframe()
+        assert len(df) == 3
+        subset_stories = [
+            s.name for s in ontology.stories() if s.name.startswith("movie:")
+        ]
+        df = ontology.story[subset_stories].dataframe()
+        assert len(df) == 505
+        df = ontology.theme[[]].dataframe()
+        assert len(df) == 0
+
+    def test_toset_descendants(self):
+        prefix = "tests/data/sample-2023.07.23"
+        ontology = totolo.files(prefix)
+        toset = ontology.theme[["romantic love"]]
+        res = ontology.theme[toset.descendants()]
+        assert sorted(t.name for t in res) == [
+            'epic love', 'first crush', 'forbidden love', 'impossible love',
+            'infatuation', 'love at first sight', 'love kindled by danger',
+            'nostalgic love', 'obsessive love', 'old-age love',
+            'romantic jealousy', 'romantic love', 'secret crush', 'tragic love',
+            'unrequited love',
+        ]
+
+    def test_toset_ancestors(self):
+        prefix = "tests/data/sample-2023.07.23"
+        ontology = totolo.files(prefix)
+        toset = ontology.theme[["love"]]
+        res = ontology.theme[toset.ancestors()]
+        assert sorted(t.name for t in res) == [
+            'human emotion', 'individual humans', 'love',
+            'personal human experience', 'the human world',
+        ]
+

--- a/tests/test_totolo.py
+++ b/tests/test_totolo.py
@@ -193,7 +193,7 @@ class TestFeatures:
 
     def test_theme_ancestors(self):
         ontology = totolo.files("tests/data/to-2023.07.09.th.txt")
-        themes = list(ontology.theme["love"].ancestors())
+        themes = [x.name for x in ontology.theme["love"].ancestors()]
         assert set(themes) == set([
             'love',
             'human emotion',
@@ -201,11 +201,11 @@ class TestFeatures:
             'personal human experience',
             'the human world',
         ])
-        assert list(TOTheme(name="foo").ancestors()) == ["foo"]
+        assert list(TOTheme(name="foo").iter_ancestor_names()) == ["foo"]
 
     def test_theme_descendants(self):
         ontology = totolo.files("tests/data/to-2023.07.09.th.txt")
-        themes = list(ontology.theme["love"].descendants())
+        themes = list(x.name for x in ontology.theme["love"].descendants())
         assert set(themes) == set([
             'love',
             'romantic love',
@@ -233,27 +233,30 @@ class TestFeatures:
             'matrimonial love',
             'filial love',
         ])
-        assert list(TOTheme(name="foo").descendants()) == ["foo"]
+        assert list(TOTheme(name="foo").iter_descendant_names()) == ["foo"]
 
     def test_story_ancestors(self):
         ontology = totolo.files("tests/data/storytree.st.txt")
-        stories = list(ontology.story["Collection: B2"].ancestors())
+        stories = [x.name for x in ontology.story["Collection: B2"].ancestors()]
         assert set(stories) == set(
             ['Collection: B2', 'Collection: A', 'Collection: B1'])
-        assert list(TOStory(name="foo").ancestors()) == ["foo"]
+        assert list(TOStory(name="foo").iter_ancestor_names()) == ["foo"]
 
     def test_story_descendants(self):
         ontology = totolo.files("tests/data/storytree.st.txt")
-        stories = list(ontology.story["Collection: B2"].descendants())
+        stories = [
+            x.name for x in ontology.story["Collection: B2"].descendants()
+        ]
         assert set(stories) == set(['Collection: B2', 'story: C'])
-        assert list(TOStory(name="foo").descendants()) == ["foo"]
+        assert list(TOStory(name="foo").iter_descendant_names()) == ["foo"]
 
     def test_dataframe(self):
         ontology = totolo.files("tests/data/sample-2023.07.23")
         df = ontology.dataframe()
         set_pandas_display_options()
-        themed_stories = len(
-            [name for name in ontology.story if not name.startswith("Collection")])
+        themed_stories = len([
+            name for name in ontology.story if not name.startswith("Collection")
+        ])
         story_themes = sum(len(list(s.iter_theme_entries()))
                            for s in ontology.story.values())
         set_pandas_display_options()
@@ -285,18 +288,6 @@ class TestFeatures:
         assert len(set(df["theme_id"])) == 1
         assert len(set(df["motivation"])) == 3
 
-    def test_toset_dataframe(self):
-        ontology = totolo.files("tests/data/sample-2023.07.23")
-        df = ontology.theme[["electricity"]].dataframe()
-        assert len(df) == 3
-        subset_stories = [
-            s.name for s in ontology.stories() if s.name.startswith("movie:")
-        ]
-        df = ontology.story[subset_stories].dataframe()
-        assert len(df) == 505
-        df = ontology.theme[[]].dataframe()
-        assert len(df) == 0
-
     def test_theme_access_list(self):
         prefix = "tests/data/sample-2023.07.23"
         ontology = totolo.files(prefix)
@@ -317,28 +308,6 @@ class TestFeatures:
         with pytest.raises(TypeError):
             toset = ontology.theme[123]
 
-    def test_toset_descendants(self):
-        prefix = "tests/data/sample-2023.07.23"
-        ontology = totolo.files(prefix)
-        toset = ontology.theme[["romantic love"]]
-        res = ontology.theme[toset.descendants()]
-        assert sorted(t.name for t in res) == [
-            'epic love', 'first crush', 'forbidden love', 'impossible love',
-            'infatuation', 'love at first sight', 'love kindled by danger',
-            'nostalgic love', 'obsessive love', 'old-age love',
-            'romantic jealousy', 'romantic love', 'secret crush', 'tragic love',
-            'unrequited love',
-        ]
-
-    def test_toset_ancestors(self):
-        prefix = "tests/data/sample-2023.07.23"
-        ontology = totolo.files(prefix)
-        toset = ontology.theme[["love"]]
-        res = ontology.theme[toset.ancestors()]
-        assert sorted(t.name for t in res) == [
-            'human emotion', 'individual humans', 'love',
-            'personal human experience', 'the human world',
-        ]
 
 class TestValidation:
     def test_cycle_warning(self):

--- a/tests/test_totolo.py
+++ b/tests/test_totolo.py
@@ -262,9 +262,13 @@ class TestFeatures:
 
     def test_dataframe_subset_with_extras(self):
         ontology = totolo.files("tests/data/sample-2023.07.23")
-        subset = ontology.theme[["electricity"]]
+        subset_stories = [
+            s.name for s in ontology.stories() if s.name.startswith("movie:")
+        ]
+        subset_themes = ontology.theme[["electricity"]]
         df = ontology.dataframe(
-            subset=subset,
+            subset_stories=subset_stories,
+            subset_themes=subset_themes,
             implied_themes=True,
             motivation=True,
             descriptions=True,
@@ -278,8 +282,20 @@ class TestFeatures:
         assert all(set(df["story_description"]))
         assert all(set(df["motivation"]))
         assert len(set(df["story_id"])) == 3
-        assert len(set(df["theme_id"])) == 67
-        assert len(set(df["motivation"])) == 36
+        assert len(set(df["theme_id"])) == 1
+        assert len(set(df["motivation"])) == 3
+
+    def test_toset_dataframe(self):
+        ontology = totolo.files("tests/data/sample-2023.07.23")
+        df = ontology.theme[["electricity"]].dataframe()
+        assert len(df) == 3
+        subset_stories = [
+            s.name for s in ontology.stories() if s.name.startswith("movie:")
+        ]
+        df = ontology.story[subset_stories].dataframe()
+        assert len(df) == 505
+        df = ontology.theme[[]].dataframe()
+        assert len(df) == 0
 
     def test_theme_access_list(self):
         prefix = "tests/data/sample-2023.07.23"

--- a/totolo/collection.py
+++ b/totolo/collection.py
@@ -1,0 +1,65 @@
+from .impl.entry import TOEntry
+from .theme import TOTheme
+from .story import TOStory
+
+
+class TOSet(set):
+    def ancestors(self):
+        return TOSet(a for o in self for a in o.ancestors())
+
+    def descendants(self):
+        return TOSet(a for o in self for a in o.descendants())
+
+    def names(self):
+        for x in self:
+            if isinstance(x, str):
+                yield x
+            else:
+                yield x.name
+
+    def dataframe(
+        self,
+        implied_themes=False,
+        motivation=False,
+        descriptions=False,
+    ):
+        subset_stories = [x for x in self if isinstance(x, TOStory)]
+        subset_themes = [x for x in self if isinstance(x, TOTheme)]
+        for obj in self:
+            return obj.ontology().dataframe(
+                subset_stories=subset_stories,
+                subset_themes=subset_themes,
+                implied_themes=implied_themes,
+                motivation=motivation,
+                descriptions=descriptions,
+            )
+        import totolo
+        return totolo.empty().dataframe(
+            implied_themes=implied_themes,
+            motivation=motivation,
+            descriptions=descriptions,
+        )
+
+    def ontology(self):
+        for x in self:
+            if hasattr(x, "ontology"):
+                return x.ontology()
+
+
+
+class TODict(dict):
+    def __getitem__(self, key):
+        if isinstance(key, str):
+            return super().__getitem__(key)
+        if isinstance(key, TOEntry):
+            return super().__getitem__(key.name)
+        try:
+            obj_iter = iter(key)
+        except TypeError as te:
+            raise TypeError(
+                f"TODict indices must be string, TOEntry, or iterable of the "
+                f"same, not {type(key)}"
+            ) from te
+        return TOSet(self.__getitem__(x) for x in obj_iter)
+
+

--- a/totolo/collection.py
+++ b/totolo/collection.py
@@ -33,7 +33,7 @@ class TOSet(set):
                 motivation=motivation,
                 descriptions=descriptions,
             )
-        import totolo
+        import totolo  # pylint: disable=cyclic-import
         return totolo.empty().dataframe(
             implied_themes=implied_themes,
             motivation=motivation,
@@ -44,7 +44,7 @@ class TOSet(set):
         for x in self:
             if hasattr(x, "ontology"):
                 return x.ontology()
-
+        return None
 
 
 class TODict(dict):
@@ -61,5 +61,3 @@ class TODict(dict):
                 f"same, not {type(key)}"
             ) from te
         return TOSet(self.__getitem__(x) for x in obj_iter)
-
-

--- a/totolo/impl/core.py
+++ b/totolo/impl/core.py
@@ -40,7 +40,9 @@ class TOObjectMeta(type):
                 to_attrs[key] = value
                 del attr[key]
         attr["_to_attrs"] = to_attrs
-        attr["_to_attrs_public"] = {k: v for k, v in to_attrs.items() if not v.private}
+        attr["_to_attrs_public"] = {
+            k: v for k, v in to_attrs.items() if not v.private
+        }
         return super().__new__(mcs, name, bases, attr)
 
     def __call__(cls, *args, **kwargs):

--- a/totolo/impl/entry.py
+++ b/totolo/impl/entry.py
@@ -61,10 +61,10 @@ class TOEntry(TOObject):
                 if fieldtype != "unknown" or not skipunknown:
                     yield field
 
-    def ancestors(self):
+    def iter_ancestor_names(self):
         yield from self._dfs("parents", self._lookup())
 
-    def descendants(self):
+    def iter_descendant_names(self):
         yield from self._dfs("children", self._lookup())
 
     def validate(self):

--- a/totolo/impl/parser.py
+++ b/totolo/impl/parser.py
@@ -12,7 +12,7 @@ from ..theme import TOTheme
 from .field import TOField
 from .keyword import TOKeyword
 
-G = r"[^\(\)\{\}\[\]]"
+G = r"[^\<\>\{\}\[\]]"
 KW_PATTERN = re.compile("([\\[\\]\\{\\}\\<\\>\\n])")
 KW_PATTERN2 = re.compile(f"(^{G}*|\\<{G}*\\>|\\[{G}*\\]|{{{G}*\\}})")
 
@@ -60,7 +60,7 @@ class TOParser:
         Turn a list of strings into kewyword items.
         Items are un-enclosed newline character separated.
         Items may contain data in () [] {} parentheses.
-        Parantheses may not contain newline characters (once they might).
+        Parantheses may not contain newline characters.
 
         This is one of the most time consuming passages in parsing a large ontology.
         """

--- a/totolo/story.py
+++ b/totolo/story.py
@@ -22,6 +22,12 @@ class TOStory(TOEntry):
     Not_Themes = sa("kwlist")
     Other_Keywords = sa("kwlist")
 
+    def ancestors(self):
+        return self.ontology().story[self.iter_ancestor_names()]
+
+    def descendants(self):
+        return self.ontology().story[self.iter_descendant_names()]
+
     def iter_theme_entries(self):
         """
         Yield (weight, TOKeyword) pairs. TOKeyword contains the comment and other

--- a/totolo/theme.py
+++ b/totolo/theme.py
@@ -12,6 +12,12 @@ class TOTheme(TOEntry):
     References = sa("list")
     Aliases = sa("list")
 
+    def ancestors(self):
+        return self.ontology().theme[self.iter_ancestor_names()]
+
+    def descendants(self):
+        return self.ontology().theme[self.iter_descendant_names()]
+
     def verbose_description(self):
         description = str(self.get("Description"))
         examples = str(self.get("Examples")).strip()


### PR DESCRIPTION
1. Can now do 
    ontology.theme[["love", "avarcie"]].ancestors().dataframe()
for example.

2. Fixes a bug whereby <capacity> was not parsed. 