### PR TITLE
Collections formatting

### DIFF
--- a/tests/data/sample-2023.07.23/notes/stories/film/film-scifi-1920s.st.txt
+++ b/tests/data/sample-2023.07.23/notes/stories/film/film-scifi-1920s.st.txt
@@ -17,6 +17,10 @@ https://en.wikipedia.org/wiki/List_of_science_fiction_films_of_the_1920s
 :: Collections
 Collection: Science fiction films of the 1920s
 
+:: Component Stories
+movie: Dr. Jekyll and Mr. Hyde (1920 II)
+movie: Alraune (1930)
+
 
 movie: Dr. Jekyll and Mr. Hyde (1920 II)
 ========================================
@@ -613,5 +617,3 @@ love triangle [Windegger, Friede, and Helius]
 :: Minor Themes
 what if I found myself in a zero gravity environment [The flight crew delighted in the experience of zero gravity on a voyage to the Moon.]
 the lust for gold [businessmen wanted to go tot he moon to extract gold from the mountains there]
-
-

--- a/tests/test_entries.py
+++ b/tests/test_entries.py
@@ -62,6 +62,8 @@ foo
 :: a very long junkline
 bar
         """)
+        assert "abstract" in entry.subtype()
+        assert entry == entry
         assert len(str(entry)) > 3
         warnings = list(entry.validate())
         assert len(warnings) == 1
@@ -73,6 +75,11 @@ bar
 
 
 class TestTOStory:
+    def test_story_subtype(self):
+        assert "story" in TOStory(name="bar").subtype()
+        assert "collection" not in TOStory(name="bar").subtype()
+        assert "collection" in TOStory(name="Collection: widget").subtype()
+
     def test_story_order(self):
         objects = [
             TOStory(name="bar"),
@@ -145,6 +152,9 @@ class TestTOStory:
 
 
 class TestTOTheme:
+    def test_story_subtype(self):
+        assert "theme" in TOTheme(name="bar").subtype()
+
     def test_theme_order(self):
         objects = [
             TOTheme(name="bar"),

--- a/tests/test_totolo.py
+++ b/tests/test_totolo.py
@@ -137,6 +137,9 @@ class TestIO:
 
     def test_write_clean(self):
         prefix1 = "tests/data/sample-2023.07.23"
+        csid = "Collection: Science fiction films of the 1920s"
+        sid1 = "movie: Dr. Jekyll and Mr. Hyde (1920 II)"
+        sid2 = "movie: Alraune (1930)"
         ontology1 = totolo.files(prefix1)
         with tempfile.TemporaryDirectory() as prefix2:
             print(f"Writing to: {prefix2}")
@@ -145,6 +148,9 @@ class TestIO:
             ontology2 = totolo.files(prefix2)
             ontology2.write_clean()
             ontology3 = totolo.files(prefix2)
+            assert sid1 in ontology2.story[csid].source
+            assert sid1 not in ontology3.story[csid].source
+            assert sid2 in ontology3.story[csid].source
             diffs = []
             for path, entries in ontology3.entries.items():
                 for idx, entry3 in enumerate(entries):
@@ -332,23 +338,25 @@ class TestOperations:
     def test_equality(self):
         o1 = totolo.files("tests/data/sample-2023.07.23")
         o2 = totolo.files("tests/data/sample-2023.07.23")
+        assert o1 == o1
         assert o1 == o2
         s1 = o1.story["movie: Dr. Jekyll and Mr. Hyde (1920 I)"]
+        t1 = o1.theme["AI assistant"]
+        assert s1 == s1
+        assert t1 == t1
+        assert s1 != t1
         s1["Major Themes"].delete_kw("mad scientist stereotype")
         assert o1 != o2
         del o1.story["movie: Dr. Jekyll and Mr. Hyde (1920 I)"]
         assert o1 != o2
-
         o1 = copy.deepcopy(o2)
         assert o1 == o2
         o1["bar theme"] = TOTheme()
         assert o1 != o2
 
-
     def test_addition(self):
         o1 = totolo.files("tests/data/sample-2023.07.23")
         o2 = totolo.files("tests/data/sample-2023.07.23")
-
         del o1["movie: Dr. Jekyll and Mr. Hyde (1920 II)"]
         s1 = o1.story["movie: Dr. Jekyll and Mr. Hyde (1920 I)"]
         s1["Major Themes"].delete_kw("mad scientist stereotype")

--- a/totolo/__init__.py
+++ b/totolo/__init__.py
@@ -2,7 +2,7 @@
 The Python interface to themeontology.org.
 """
 
-__version__ = "1.5.3"
+__version__ = "1.6.0"
 
 from totolo.api import TORemote, empty, files
 

--- a/totolo/impl/entry.py
+++ b/totolo/impl/entry.py
@@ -27,6 +27,8 @@ class TOEntry(TOObject):
         return str(self) < str(other)
 
     def __eq__(self, other):
+        if self is other:
+            return True
         if type(self) is not type(other):
             return False
         if self.name != other.name:
@@ -67,6 +69,9 @@ class TOEntry(TOObject):
 
     def __delitem__(self, key):
         del self.fields[key]
+
+    def subtype(self):
+        return "abstract entry"
 
     def iter_fields(self, reorder=False, skipunknown=False):
         if reorder:

--- a/totolo/impl/parser.py
+++ b/totolo/impl/parser.py
@@ -170,14 +170,13 @@ class TOParser:
         entries = []
         for idx, entrylines in enumerate(TOParser.iter_entries(lines)):
             entry = cls.make_story(entrylines)
-            if idx == 0:
-                mycols = entry.get("Collections").parts
-                if mycols and mycols[0] == entry.sid:
-                    collection_entry = entry
-            if idx > 0 and collection_entry:
+            if entry.subtype()=="collection":
+                collection_entry = entry if idx == 0 else None
+            entries.append(entry)
+        if collection_entry:
+            for entry in entries[1:]:
                 field = collection_entry.setdefault("Component Stories")
                 field.parts.append(entry.sid)
-            entries.append(entry)
         return entries
 
     @classmethod

--- a/totolo/story.py
+++ b/totolo/story.py
@@ -22,6 +22,11 @@ class TOStory(TOEntry):
     Not_Themes = sa("kwlist")
     Other_Keywords = sa("kwlist")
 
+    def subtype(self):
+        if self.name.startswith("Collection: "):
+            return "collection"
+        return "story"
+
     def ancestors(self):
         return self.ontology().story[self.iter_ancestor_names()]
 

--- a/totolo/theme.py
+++ b/totolo/theme.py
@@ -12,6 +12,9 @@ class TOTheme(TOEntry):
     References = sa("list")
     Aliases = sa("list")
 
+    def subtype(self):
+        return "theme"
+
     def ancestors(self):
         return self.ontology().theme[self.iter_ancestor_names()]
 

--- a/totolo/themeontology.py
+++ b/totolo/themeontology.py
@@ -303,23 +303,26 @@ class ThemeOntology(TOObject):
 
     def _writefile(self, path, entries, cleaned):
         cskey = "Component Stories"
+        collection_entry = None
         dirname = os.path.dirname(path)
         if dirname and not os.path.exists(dirname):
             os.makedirs(dirname)
+        for idx, entry in enumerate(entries):
+            if entry.subtype()=="collection":
+                collection_entry = entry if idx == 0 else None
         with open(path, "w", encoding='utf-8') as fhandle:
             sids = set(e.name for e in entries)
             for idx, entry in enumerate(entries):
-                if idx == 0 and entry.name in entry["Collections"]:
+                if entry is collection_entry:
                     field = entry.get(cskey)
                     all_parts = list(field)
-                    parts = [x for x in all_parts if x not in sids]
-                    if parts != all_parts:
-                        entry = copy.deepcopy(entry)
-                        if parts:
-                            field = entry.setdefault(cskey)
-                            field.parts = parts
-                        else:
-                            entry.delete(cskey)
+                    parts_ex_implied = [x for x in all_parts if x not in sids]
+                    entry = copy.deepcopy(entry)
+                    if parts_ex_implied:
+                        field = entry.setdefault(cskey)
+                        field.parts = parts_ex_implied
+                    else:
+                        entry.delete(cskey)
                 lines = entry.text_canonical() if cleaned else entry.text_original()
                 fhandle.write(lines)
                 fhandle.write("\n\n" if cleaned else "\n")

--- a/totolo/util/mergefiles.py
+++ b/totolo/util/mergefiles.py
@@ -36,7 +36,11 @@ def mergefiles(paths, reorder=True, dryrun=False):
 
     for path, entries in final_to.entries.items():
         if reorder:
-            entries.sort(key=lambda x: (not x.name.startswith("Collection:"), x.name))
+            entries.sort(key=lambda x: (
+                1 if x.subtype()=="collection" else 2,
+                x.name.casefold(),
+                x.name
+            ))
         prefix = "Would have written" if dryrun else "Writing"
         log.info(f"{prefix}: {path}: {len(entries)} entries")
 


### PR DESCRIPTION
- Change the way collections are defined. Now a story entry is a collection if its name starts with "Collection: " and it's no longer neccessary to include itself as a component story in itself.
- Change the way entries are ordered. Now alphabetically without case, but with collections first.