### PR TITLE
add organize_collections; makejson to use organize_collections by defult

### DIFF
--- a/tests/data/collection-reorg.st.txt
+++ b/tests/data/collection-reorg.st.txt
@@ -1,0 +1,67 @@
+Collection: A
+=============
+
+:: Title
+A
+
+:: Date
+2025
+
+:: Description
+Collection A.
+
+:: Component Stories
+
+
+Collection: B
+=============
+
+:: Title
+B
+
+:: Date
+2025
+
+:: Description
+Collection B.
+
+:: Component Stories
+
+
+story: A
+========
+
+:: Title
+A
+
+:: Date
+2025
+
+:: Description
+Story A.
+
+:: Collections
+Collection: B
+
+:: Minor Themes
+foo [bar]
+
+
+story: B
+========
+
+:: Title
+B
+
+:: Date
+2025
+
+:: Description
+Story B.
+
+:: Collections
+Collection: A
+Collection: B
+
+:: Minor Themes
+foo [bar]

--- a/tests/utils/test_makejson.py
+++ b/tests/utils/test_makejson.py
@@ -126,3 +126,27 @@ class TestMakeJson:
         dd = json.loads(out)
         assert "source" in dd["stories"][0]
         assert "ratings" in dd["stories"][0]
+
+    def test_reorg_default(self, capsys):
+        p1 = "tests/data/collection-reorg.st.txt"
+        testargs = ["makejson", p1]
+        with patch.object(sys, 'argv', testargs):
+            totolo.util.makejson.main()
+        out, _err = capsys.readouterr()
+        dd = json.loads(out)
+        for story_dict in dd["stories"]:
+            assert "collections" not in story_dict
+        assert dd["collections"][0]["component stories"] == ["story: B"]
+        assert dd["collections"][1]["component stories"] == ["story: A", "story: B"]
+
+    def test_no_reorg(self, capsys):
+        p1 = "tests/data/collection-reorg.st.txt"
+        testargs = ["makejson", p1, "--no-reorg"]
+        with patch.object(sys, 'argv', testargs):
+            totolo.util.makejson.main()
+        out, _err = capsys.readouterr()
+        dd = json.loads(out)
+        for story_dict in dd["stories"]:
+            assert "collections" in story_dict
+        for collection_dict in dd["collections"]:
+            assert "collections" not in collection_dict

--- a/totolo/__init__.py
+++ b/totolo/__init__.py
@@ -2,7 +2,7 @@
 The Python interface to themeontology.org.
 """
 
-__version__ = "1.9.4"
+__version__ = "1.9.5"
 
 from totolo.api import TORemote, empty, files
 

--- a/totolo/themeontology.py
+++ b/totolo/themeontology.py
@@ -302,6 +302,25 @@ class ThemeOntology(TOObject):
                     self.story[cstory_name].parents.add(story.name)
         return self
 
+    def organize_collections(self):
+        """
+        Pull out any collection specified on a story and instead put the story
+        as a component on that collection. This effectively removes the
+        :: Collections field.
+        """
+        field_list = []
+        for story in self.stories():
+            for pstory_name in story["Collections"]:
+                if  pstory_name != story.name and pstory_name in self.story:
+                    comp_field = self.story[pstory_name].setdefault("Component Stories")
+                    comp_field.parts.append(story.name)
+                    field_list.append(comp_field)
+            if not story["Collections"].frozen:
+                story["Collections"].parts.clear()
+        for fl in field_list:
+            fl.parts = sorted(set(fl.parts))
+        return self
+
     def _writefile(self, path, entries, cleaned):
         cskey = "Component Stories"
         collection_entry = None

--- a/totolo/util/help.py
+++ b/totolo/util/help.py
@@ -13,13 +13,13 @@ To learn more about python usage, follow the github link.
 
 The following commands are provided:
 """.strip())
-    for name in [
+    for name in sorted([
         "makelist",
         "mergelist",
         "mergefiles",
         "makejson",
         "help",
-    ]:
+    ]):
         command = f'to-{name}'
         print(f"  {command:<15}" + ("" if shutil.which(command) else "  (not installed)"))
     print("""

--- a/totolo/util/makejson.py
+++ b/totolo/util/makejson.py
@@ -120,16 +120,16 @@ def main():
         epilog=main.__doc__
     )
     parser.add_argument("source", nargs="*", help=
-                        "Paths to include or version to download. "
-                        "If a single argument matching tag pattern vYYYY.MM is given, "
-                        "it will be interpreted as a version. "
-                        "Otherwise the arguments will be treated as one or more local paths. "
+        "Paths to include or version to download. "
+        "If a single argument matching tag pattern vYYYY.MM is given, "
+        "it will be interpreted as a version. "
+        "Otherwise the arguments will be treated as one or more local paths. "
     )
     parser.add_argument("-p", "--path", help="Path to the ontology.")
     parser.add_argument("--verbosity", default="official", help=
-                        "Which fields to include. "
-                        "'official': (default) include fields for official release. "
-                        "'all': include all fields. "
+        "Which fields to include. "
+        "'official': (default) include fields for official release. "
+        "'all': include all fields. "
     )
     parser.add_argument(
         "-v", "--version", help="Named version to use. If not specified the latest version of the "
@@ -138,6 +138,11 @@ def main():
     parser.add_argument("-t", action='store_true', help="Include themes.")
     parser.add_argument("-s", action='store_true', help="Include stories.")
     parser.add_argument("-c", action='store_true', help="Include collections.")
+    parser.add_argument('--reorg', action=argparse.BooleanOptionalAction, default=True, help=
+        "If set (default) reorganize the ontology in some ways. "
+        "In particular, remove collection entries on stories and add corresponding "
+        "component entries on the collections instead. "
+    )
     args = parser.parse_args()
 
     if sum(1 for x in [args.path, args.version, args.source] if x) > 1:
@@ -154,6 +159,9 @@ def main():
         ontology = totolo.remote.version(args.version)
     else:
         ontology = totolo.remote()
+
+    if args.reorg:
+        ontology.organize_collections()
 
     try:
         if not any([args.t, args.s, args.c]):


### PR DESCRIPTION
- Add function to organize collections - pulls stories with defined :: Collections up as :: Component Stories of those collections.
- to-makejson uses organize_collections by default (disable with --no-reorg).
