### PR TITLE
Exclude v0.* tags from remote.versions(); bump 2.1.3

### DIFF
--- a/tests/test_totolo.py
+++ b/tests/test_totolo.py
@@ -68,7 +68,7 @@ class TestIO:
         precache_remote_resources()
         versions = [v for v, _ in totolo.remote.versions()]
         assert "v2023.06" in versions
-        assert "v0.3.3" in versions
+        assert "v0.3.3" not in versions  # v0.* package tags are excluded from listings
         with pytest.raises(ValueError):
             totolo.remote.version("gobbledygook")
 

--- a/totolo/__init__.py
+++ b/totolo/__init__.py
@@ -5,7 +5,7 @@ from totolo.impl.api import TORemote, empty, files
 
 
 remote = TORemote()
-__version__ = "2.1.2"
+__version__ = "2.1.3"
 __ALL__ = [
     empty,
     files,

--- a/totolo/impl/api.py
+++ b/totolo/impl/api.py
@@ -1,4 +1,5 @@
 import json
+import re
 import urllib.request
 import functools
 
@@ -7,6 +8,16 @@ from ..ontology import ThemeOntology
 
 DEFAULT_URL = "https://github.com/theme-ontology/theming/"
 API_URL = "https://api.github.com/repos/theme-ontology/theming/"
+
+
+def _is_ontology_release(tag):
+    """Whether a release tag is a dated ontology snapshot (e.g. v2025.04).
+
+    v0.* tags are early totolo package releases, not ontology versions, and
+    cannot be built into a corpus -- exclude them from version listings.
+    """
+    match = re.match(r"v?(\d+)", tag)
+    return not (match and int(match.group(1)) == 0)
 
 
 def files(paths=None):
@@ -61,7 +72,9 @@ class TORemote:
 
     def versions(self):
         for item in self._get("releases"):
-            yield item["tag_name"], item["name"]
+            tag = item["tag_name"]
+            if _is_ontology_release(tag):
+                yield tag, item["name"]
 
     @functools.lru_cache
     def _get(self, endpoint):

--- a/totolo/util/makejson.py
+++ b/totolo/util/makejson.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import sys
 from collections import defaultdict
 
 import totolo.lib.argparse
@@ -143,7 +144,9 @@ def main():
             verbosity=args.verbosity,
         )
     try:
-        print(json.dumps(dd, indent=4, ensure_ascii=False))
+        sys.stdout.buffer.write(json.dumps(dd, indent=4, ensure_ascii=False).encode("utf-8"))
+        sys.stdout.buffer.write(b"\n")
+        sys.stdout.buffer.flush()
     except BrokenPipeError:  # pragma: no cover
         pass
 

--- a/totolo/util/mergelist.py
+++ b/totolo/util/mergelist.py
@@ -1,4 +1,5 @@
 import argparse
+import sys
 from collections import defaultdict
 
 import totolo
@@ -256,6 +257,7 @@ def main():
         help="Read and report on stdout, but do not write changes to ontology.",
         action="store_true",
     )
+    sys.stdout.reconfigure(encoding='utf-8')
     args = parser.parse_args()
     mergelist(args.path_changes, args.path_ontology, args.dryrun)
 


### PR DESCRIPTION
## What
- `remote.versions()` now excludes `v0.*` tags (early package releases, not dated ontology snapshots) so listings/backfills only surface real ontology releases. `version(v0.3.3)` still works for explicit fetches.
- Bump `__version__` to 2.1.3.

## Why
`makejson` cannot build a corpus from `v0.*` tags; they caused failures when backfilling the prod search site from `totolo.remote.versions()`.

## Validation
- pylint 10.00/10, pytest coverage 100% (111 passed) locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)