### PR TITLE
Validate dangling component-story references

### DIFF
--- a/tests/data/dangling-component.st.txt
+++ b/tests/data/dangling-component.st.txt
@@ -1,0 +1,28 @@
+movie: Real Movie (2000)
+========================
+
+:: Title
+Real Movie
+
+:: Date
+2000-01-01
+
+:: Description
+A real movie that exists as a story.
+
+
+Collection: Test Collection
+===========================
+
+:: Title
+Test Collection
+
+:: Date
+2000
+
+:: Description
+A collection that lists one real story and one missing story.
+
+:: Component Stories
+movie: Real Movie (2000)
+movie: Missing Movie (1999)

--- a/tests/test_totolo.py
+++ b/tests/test_totolo.py
@@ -406,6 +406,19 @@ class TestValidation:
         warnings = list(ontology._impl.validate_entries())
         assert any("Multiple TOStory with name" in x for x in warnings)
 
+    def test_component_warning(self):
+        ontology = totolo.files("tests/data/dangling-component.st.txt")
+        warnings = list(ontology._impl.validate_components())
+        # The missing component story is flagged...
+        assert any(
+            "Undefined 'component story'" in x and "movie: Missing Movie (1999)" in x
+            for x in warnings
+        )
+        # ...while the component story that exists is not.
+        assert not any("movie: Real Movie (2000)" in x for x in warnings)
+        # And it surfaces through the top-level validate().
+        assert any("Undefined 'component story'" in x for x in ontology.validate())
+
 
 class TestOperations:
     def test_equality(self):

--- a/totolo/__init__.py
+++ b/totolo/__init__.py
@@ -5,7 +5,7 @@ from totolo.impl.api import TORemote, empty, files
 
 
 remote = TORemote()
-__version__ = "2.1.3"
+__version__ = "2.1.4"
 __ALL__ = [
     empty,
     files,

--- a/totolo/impl/to_base.py
+++ b/totolo/impl/to_base.py
@@ -159,6 +159,7 @@ class TOBase(TOObject):
     def validate(self):
         yield from self._impl.validate_entries()
         yield from self._impl.validate_storythemes()
+        yield from self._impl.validate_components()
         yield from self._impl.validate_cycles()
 
     def write(self, prefix=None, cleaned=False, verbose=False):
@@ -298,6 +299,14 @@ class TOImpl:
                     if kwfield.keyword not in self.o.theme:
                         yield (f"{story.name}: Undefined '{weight} theme' with "
                                f"name '{kwfield.keyword}'")
+
+    def validate_components(self):
+        """Detect component stories of collections that reference undefined stories."""
+        for story in self.o.stories():
+            for component_name in story.get("Component Stories"):
+                if component_name not in self.o.story:
+                    yield (f"{story.name}: Undefined 'component story' with "
+                           f"name '{component_name}'")
 
     def validate_cycles(self):
         """Detect cycles (stops after first cycle encountered)."""


### PR DESCRIPTION
## What

Adds a new ontology validation that flags **collection `Component Stories` entries referencing stories that don't exist** in the ontology — the same class of issue as the existing "Undefined theme" check, but for collection membership.

## Why

The themeontology data has real cases of this: e.g. *Marvel Cinematic Universe* / *Spider-Man* list `movie: SpiderMan: No Way Home (2021)`, and *TRIPOD films* lists `movie: Unforgiven (1992)` (which exists only without the `movie: ` prefix) — none of which resolve to a story. Nothing currently surfaces these.

## How

- New `TOImpl.validate_components()` (in `to_base.py`), mirroring `validate_storythemes()`: for each story, any `Component Stories` name not in `self.o.story` yields a warning.
- Wired into `ThemeOntology.validate()` (so it flows through `print_warnings()` and the `to-validate` CLI).
- New fixture `tests/data/dangling-component.st.txt` + `TestValidation::test_component_warning`.
- Version bumped to **2.1.4**.

## Tests

`pytest --cov=totolo` → **112 passed, 100% coverage**.